### PR TITLE
fix deser of comment field

### DIFF
--- a/guineapig-webapp-os/src/it/java/com/wixpress/guineapig/web/ExperimentsControllerIT.scala
+++ b/guineapig-webapp-os/src/it/java/com/wixpress/guineapig/web/ExperimentsControllerIT.scala
@@ -64,7 +64,7 @@ class ExperimentsControllerIT extends SpecificationWithEnvSupport {
       postExperiment(id)
 
       val comment = "terminate reason"
-      val terminateRes = httpDriver.post(s"$url/Experiment/$id/terminate", comment)
+      val terminateRes = httpDriver.postText(s"$url/Experiment/$id/terminate", comment)
       terminateRes.getSuccess must beTrue
 
       checkExperimentContains(experimentId = id, "\"state\":\"ended\"", s"""comment":"$comment""")
@@ -75,7 +75,7 @@ class ExperimentsControllerIT extends SpecificationWithEnvSupport {
       postExperiment(id)
 
       val comment = "pause reason"
-      val pauseRes = httpDriver.post(s"$url/Experiment/$id/pause", comment)
+      val pauseRes = httpDriver.postText(s"$url/Experiment/$id/pause", comment)
       pauseRes.getSuccess must beTrue
 
       checkExperimentContains(experimentId = id, "\"paused\":true", s"""comment":"$comment""")
@@ -87,7 +87,7 @@ class ExperimentsControllerIT extends SpecificationWithEnvSupport {
       httpDriver.post(s"$url/Experiment/$id/pause", "pause reason")
 
       val comment = "resume reason"
-      val resumeRes = httpDriver.post(s"$url/Experiment/$id/resume", comment)
+      val resumeRes = httpDriver.postText(s"$url/Experiment/$id/resume", comment)
       resumeRes.getSuccess must beTrue
 
       checkExperimentContains(experimentId = id, "\"paused\":false", s"""comment":"$comment""")

--- a/guineapig-webapp-os/src/main/java/com/wixpress/guineapig/web/ExperimentsController.java
+++ b/guineapig-webapp-os/src/main/java/com/wixpress/guineapig/web/ExperimentsController.java
@@ -63,12 +63,7 @@ public class ExperimentsController extends BaseController {
         }
     }
 
-    @RequestMapping(
-            value = "/Experiments",
-            method = {RequestMethod.POST},
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE
-            )
+    @RequestMapping(value = "/Experiments", method = {RequestMethod.POST})
     @ResponseBody
     public GuineapigResult newExperiment(@RequestBody final UiExperiment uiExperiment, final HttpSession session) throws Exception {
         try {
@@ -79,7 +74,7 @@ public class ExperimentsController extends BaseController {
         }
     }
 
-    @RequestMapping(value = "/Experiment/{experimentId}", method = {RequestMethod.POST, RequestMethod.PUT})
+    @RequestMapping(value = "/Experiment/{experimentId}", method = {RequestMethod.PUT})
     @ResponseBody
     public GuineapigResult updateExperiment(@RequestBody final UiExperiment uiExperiment, final HttpSession session) throws Exception {
         try {
@@ -91,12 +86,10 @@ public class ExperimentsController extends BaseController {
         }
     }
 
-    @RequestMapping(value = "/Experiment/{experimentId}/terminate", method = {RequestMethod.POST})
+    @RequestMapping(value = "/Experiment/{experimentId}/terminate", method = {RequestMethod.POST}, consumes = {"text/plain"})
     @ResponseBody
     public GuineapigResult terminateExperiment(
-            @PathVariable("experimentId") final int experimentId,
-            @RequestBody final String comment,
-            final HttpSession session) throws Exception {
+            @PathVariable("experimentId") final int experimentId, @RequestBody final String comment,final HttpSession session) throws Exception {
         try {
             Experiment experiment = experimentService.getExperimentById(experimentId);
             List<Experiment> allExperiments = experimentService.getAllExperiments();
@@ -109,13 +102,13 @@ public class ExperimentsController extends BaseController {
         }
     }
 
-    @RequestMapping(value = "/Experiment/{experimentId}/pause", method = {RequestMethod.POST})
+    @RequestMapping(value = "/Experiment/{experimentId}/pause", method = {RequestMethod.POST}, consumes = {"text/plain"})
     @ResponseBody
     public GuineapigResult pauseExperiment(@PathVariable("experimentId") final int experimentId, @RequestBody final String comment, final HttpSession session) throws Exception {
         return success(experimentService.pauseExperiment(experimentId, comment, getUser(session).getEmail()));
     }
 
-    @RequestMapping(value = "/Experiment/{experimentId}/resume", method = {RequestMethod.POST})
+    @RequestMapping(value = "/Experiment/{experimentId}/resume", method = {RequestMethod.POST}, consumes = {"text/plain"})
     @ResponseBody
     public GuineapigResult resumeExperiment(@PathVariable("experimentId") final int experimentId, @RequestBody final String comment, final HttpSession session) throws Exception {
         return success(experimentService.resumeExperiment(experimentId, comment, getUser(session).getEmail()));

--- a/petri-ui-statics/statics/scripts/scripts.js
+++ b/petri-ui-statics/statics/scripts/scripts.js
@@ -134,14 +134,14 @@ angular.module('uiPetriServices', ['ngResource', 'ng'])
     });
 
     Experiment.restStop = $resource(api.stopExperiment, {}, {
-      stop: { method: 'POST', params: {experimentId: '@experimentId'} }
+      stop: { method: 'POST', headers: {'Content-Type': 'text/plain'}, params: {experimentId: '@experimentId'} }
     });
 
     Experiment.restPause = $resource(api.pauseExperiment, {}, {
-      pause: { method: 'POST', params: {experimentId: '@experimentId'} }
+      pause: { method: 'POST', headers: {'Content-Type': 'text/plain'}, params: {experimentId: '@experimentId'} }
     });
     Experiment.restResume = $resource(api.resumeExperiment, {}, {
-      resume: { method: 'POST', params: {experimentId: '@experimentId'} }
+      resume: { method: 'POST', headers: {'Content-Type': 'text/plain'}, params: {experimentId: '@experimentId'} }
     });
     Experiment.restExperimentSkeleton = $resource(api.experimentSkeleton);
     Experiment.restExperimentHistory = $resource(api.history, {}, {


### PR DESCRIPTION
ui should send 'Content-Type:text/plain' for relevant requests, so that 'comment' field is properly sent for pause/resume/terminate calls