### PR TITLE
Catching adapter exceptions and writing them

### DIFF
--- a/laboratory-servlet-api-integration/src/it/scala/com/wixpress/petri/laboratory/AmplitudeTestGroupAssignmentTrackerIT.scala
+++ b/laboratory-servlet-api-integration/src/it/scala/com/wixpress/petri/laboratory/AmplitudeTestGroupAssignmentTrackerIT.scala
@@ -49,5 +49,12 @@ class AmplitudeTestGroupAssignmentTrackerIT extends SpecificationWithJUnit with 
       amplitudeTestGroupAssignmentTracker.newAssignment(assignment)
       amplitudeDriver.assertThatBiServerWasCalled("httpapi")
     }
+
+    "don't throw an exception if failing to write to bi adapter" in new Context{
+      val failingAmplitudeAdapter = AmplitudeAdapterBuilder.create(
+        s"http://localhost:$port/notexisting", "198e3469868de498f5d67581d6de4518", null)
+      val failingAmplitudeTestGroupAssignmentTracker = new BiTestGroupAssignmentTracker(failingAmplitudeAdapter)
+      failingAmplitudeTestGroupAssignmentTracker.newAssignment(assignment) must not(throwA[Throwable])
+    }
   }
 }

--- a/laboratory-servlet-api-integration/src/main/scala/com/wixpress/petri/laboratory/BiTestGroupAssignmentTracker.scala
+++ b/laboratory-servlet-api-integration/src/main/scala/com/wixpress/petri/laboratory/BiTestGroupAssignmentTracker.scala
@@ -9,7 +9,13 @@ import com.wixpress.petri.experiments.domain.Assignment
 class BiTestGroupAssignmentTracker(adapter: BiAdapter) extends TestGroupAssignmentTracker {
   override def newAssignment(assignment: Assignment): Unit = {
     val event = BiPetriEvent.fromAssignment(assignment)
-    adapter.sendEvent(event)
+    try {
+      adapter.sendEvent(event)
+    } catch {
+      case e: Throwable =>
+        println(s"Failed to write BI Event to: ${adapter.getClass.getName} for experiment ${assignment.getExperimentId}")
+        e.printStackTrace()
+    }
   }
 }
 


### PR DESCRIPTION
The conduction shouldn't fail if the adapters throw exceptions